### PR TITLE
Add Windows (%.%) and Unix (${.}) styles (fix #1 & #2)

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,9 +6,19 @@ function expandenv(string, env) {
 
   env = merge(process.env, (env || {}))
 
-  return string.replace(/\$[\w]+/g, function(match) {
+  string = string.replace(/\$[\w]+/g, function(match) {
     return env[match.replace('$', '')] || match
   })
+  
+  string = string.replace(/%.+?%/g, function(match) {
+    return env[match.substr(1, match.length - 2)] || match
+  })
+  
+  string = string.replace(/\$\{.+\}/g, function(match) {
+    return env[match.substr(2, match.length - 3)] || match
+  })
+    
+  return string
 }
 
 function merge(orig, newObj) {

--- a/test/test.js
+++ b/test/test.js
@@ -1,15 +1,57 @@
 var expandenv = require('../index')
 
 describe('expandenv', function() {
-
-  it('should expand environment variables in strings', function() {
-    var example = "The current working directory is: $PWD"
-    expandenv(example).should.match("The current working directory is: " + process.env.PWD)
+  
+  it('should leave strings without environment variables untouched', function() {
+    var example = "This is a string"
+    expandenv(example).should.match(example)
   })
 
-  it('should let you pass in your own variables', function() {
-    var example = 'Hi $PARENT'
-    expandenv(example, {PARENT: 'Mom'}).should.match("Hi Mom")
+  describe('Original style', function() {
+    it('should expand environment variables in strings', function() {
+      var example = "The current working directory is: $PWD"
+      expandenv(example).should.match("The current working directory is: " + process.env.PWD)
+    })
+
+    it('should let you pass in your own variables', function() {
+      var example = 'Hi $PARENT'
+      expandenv(example, {PARENT: 'Mom'}).should.match("Hi Mom")
+    })
   })
 
+  describe('Windows style (%...%)', function() {
+    
+    it('should expand environment variables in strings', function() {
+      var example = "The current working directory is: %PWD%!"
+      expandenv(example).should.match("The current working directory is: " + process.env.PWD + "!")
+    })
+
+    it('should let you pass in your own variables', function() {
+      var example = 'Hi %PARENT%'
+      expandenv(example, {PARENT: 'Mom'}).should.match("Hi Mom")
+    })
+  })
+ 
+  describe('Unix style (${...})', function() {
+    
+    it('should expand environment variables in strings', function() {
+      var example = "The current working directory is: ${PWD}!"
+      expandenv(example).should.match("The current working directory is: " + process.env.PWD + "!")
+    })
+
+    it('should let you pass in your own variables', function() {
+      var example = 'Hi ${PARENT}'
+      expandenv(example, {PARENT: 'Mom'}).should.match("Hi Mom")
+    })
+  })
+  
+  // Make sure it works even though we wouldn't expect it to be used this way
+  describe('Mixed styles', function() {
+    
+    it('should expand environment variables in strings with a mix of styles', function() {
+      var example = "$PWD%PWD%${PWD}"
+      var pwd = process.env.PWD
+      expandenv(example).should.match(pwd + pwd + pwd)
+    })
+  })
 })


### PR DESCRIPTION
Adds support for %...% and ${...} style variables to the same function.

This could however be considered a breaking change, so if you're not happy with that, there's a couple of other ways of doing it I can think of:
- Add an `.extra()`? method on the expandenv object that has the extra functionality:

```
expandenv.extra("Some string with $vars or %vars% or ${vars}")
```
- Add a third `options` parameter with flags `withWindows` and `withBraces`?:

```
expandenv("Some string with $vars or %vars% or ${vars}", {}, 
    { withWindows: true, withBraces: true })
```

My use-case for this is a multi-platform application and the input will be user-entered strings, so I do need a single function that can handle all cases.

CC @sp00x
